### PR TITLE
added a carousel option for shoes with multiple images of a color. if…

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -37,7 +37,7 @@ export default function RootLayout({
         />
       </head>
       <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased overflow-y-scroll`}
+        className={`${geistSans.variable} ${geistMono.variable} antialiased overflow-y-scroll overflow-x-hidden min-w-[400px]`}
       >
         <ConfigFetch />
         <Navbar />

--- a/src/components/Cart/CartItem.tsx
+++ b/src/components/Cart/CartItem.tsx
@@ -15,15 +15,22 @@ const CartItem: React.FC<Props> = observer(({ cartItem, compact = false }) => {
   const { shoe, selectedColor, selectedSize, selectedPrice, quantity } =
     cartItem;
 
+  const selectedColorImages = shoe.colorImages[selectedColor];
+  const imageUrl = Array.isArray(selectedColorImages)
+    ? selectedColorImages[0]
+    : selectedColorImages;
+
   return (
     <div className={`flex gap-4 border-b pb-4 last:border-b-0 last:pb-0`}>
-      <Image
-        width={96}
-        height={96}
-        src={shoe.colorImages[selectedColor]}
-        alt={shoe.name}
-        className="w-40 object-cover rounded"
-      />
+      <div className="w-40 relative">
+        <Image
+          src={imageUrl}
+          alt={shoe.name}
+          fill
+          sizes="(max-width: 768px) 100vw, 160px"
+          className="object-cover rounded"
+        />
+      </div>
       <div className="flex flex-col justify-between flex-1">
         <div className="flex justify-between">
           <div>

--- a/src/components/Cart/CartItem.tsx
+++ b/src/components/Cart/CartItem.tsx
@@ -16,9 +16,7 @@ const CartItem: React.FC<Props> = observer(({ cartItem, compact = false }) => {
     cartItem;
 
   const selectedColorImages = shoe.colorImages[selectedColor];
-  const imageUrl = Array.isArray(selectedColorImages)
-    ? selectedColorImages[0]
-    : selectedColorImages;
+  const imageUrl = selectedColorImages[0];
 
   return (
     <div className={`flex gap-4 border-b pb-4 last:border-b-0 last:pb-0`}>

--- a/src/components/Cart/__mocks__/mockCartItem.ts
+++ b/src/components/Cart/__mocks__/mockCartItem.ts
@@ -8,7 +8,7 @@ export const mockCartItem: CartItem = {
     sizes: ['9'],
     colors: ['Pink'],
     colorImages: {
-      Pink: '/images/ultraboost-pink.jpg',
+      Pink: ['/images/ultraboost-pink.jpg'],
     },
     description: '',
     prices: {

--- a/src/components/Logo.tsx
+++ b/src/components/Logo.tsx
@@ -2,16 +2,18 @@ import Link from 'next/link';
 import Image from 'next/image';
 
 const Logo: React.FC = () => (
-  <div className="flex-shrink-0">
-    <Link href="/">
-      <Image
-        src="/SneakPeakLogo.png"
-        alt="SneakPeak Nav Logo"
-        width={100}
-        height={100}
-        className="object-contain transition-all duration-300 hover:opacity-70"
-      />
-    </Link>
+  <div className="max-w-[150px] sm:max-w-none">
+    <div className="flex-shrink-0">
+      <Link href="/">
+        <Image
+          src="/SneakPeakLogo.png"
+          alt="SneakPeak Nav Logo"
+          width={100}
+          height={100}
+          className="object-contain transition-all duration-300 hover:opacity-70"
+        />
+      </Link>
+    </div>
   </div>
 );
 

--- a/src/components/Nav/Navbar.tsx
+++ b/src/components/Nav/Navbar.tsx
@@ -34,9 +34,11 @@ const Navbar: React.FC = () => {
 
   return (
     <>
-      <nav className="bg-gray-900 p-4 relative">
+      <nav className="bg-gray-900 p-4 relative z-40">
         <div className="container mx-auto flex items-center justify-between">
-          <Logo />
+          <div className="max-w-[150px] sm:max-w-none">
+            <Logo />
+          </div>
           <div className="absolute left-1/2 transform -translate-x-1/2 flex items-center justify-center">
             <DesktopMenu />
           </div>

--- a/src/components/Nav/Navbar.tsx
+++ b/src/components/Nav/Navbar.tsx
@@ -36,9 +36,7 @@ const Navbar: React.FC = () => {
     <>
       <nav className="bg-gray-900 p-4 relative z-40">
         <div className="container mx-auto flex items-center justify-between">
-          <div className="max-w-[150px] sm:max-w-none">
-            <Logo />
-          </div>
+          <Logo />
           <div className="absolute left-1/2 transform -translate-x-1/2 flex items-center justify-center">
             <DesktopMenu />
           </div>

--- a/src/components/ProductPages/AddToCartButton.tsx
+++ b/src/components/ProductPages/AddToCartButton.tsx
@@ -19,7 +19,7 @@ const AddToCartButton: React.FC<AddToCartButtonProps> = ({
   return (
     <div className="mt-2">
       <button
-        className="bg-blue-500 text-white px-4 py-2 rounded-md w-full disabled:opacity-50"
+        className="bg-blue-500 text-white px-4 py-2 rounded-md w-full disabled:opacity-50 cursor-pointer"
         onClick={handleClick}
         disabled={disabled}
       >

--- a/src/components/ProductPages/ShoeCard.tsx
+++ b/src/components/ProductPages/ShoeCard.tsx
@@ -15,7 +15,7 @@ interface ShoeCardProps {
   brand: string;
   sizes: string[];
   colors: string[];
-  colorImages: { [color: string]: string };
+  colorImages: { [color: string]: string[] };
   description: string;
   prices: { [color: string]: number };
   onAddToCart?: (
@@ -39,11 +39,17 @@ const ShoeCard: React.FC<ShoeCardProps> = observer(
   }) => {
     const [activeColor, setActiveColor] = useState<string>(colors[0]);
     const [activeSize, setActiveSize] = useState<string | null>(null);
-    const [activeImage, setActiveImage] = useState(colorImages[colors[0]]);
+    const [activeImageList, setActiveImageList] = useState<string[]>(
+      colorImages[colors[0]]
+    );
     const [activePrice, setActivePrice] = useState<number>(prices[colors[0]]);
 
     useEffect(() => {
-      setActiveImage(colorImages[activeColor]);
+      setActiveImageList(
+        Array.isArray(colorImages[activeColor])
+          ? colorImages[activeColor]
+          : [colorImages[activeColor]]
+      );
       setActivePrice(prices[activeColor]);
     }, [activeColor, colorImages, prices]);
 
@@ -58,7 +64,7 @@ const ShoeCard: React.FC<ShoeCardProps> = observer(
     const handleAddToCart = () => {
       if (activeColor && activeSize) {
         const shoe: Shoe = {
-          picture_url: activeImage,
+          picture_url: activeImageList[0],
           name,
           brand,
           sizes,
@@ -81,7 +87,7 @@ const ShoeCard: React.FC<ShoeCardProps> = observer(
     return (
       <div className="bg-white shadow-lg rounded-lg overflow-hidden flex flex-col h-full">
         <ShoeImage
-          activeImage={activeImage}
+          images={activeImageList}
           name={name}
           activeColor={activeColor}
         />

--- a/src/components/ProductPages/ShoeImage.test.tsx
+++ b/src/components/ProductPages/ShoeImage.test.tsx
@@ -1,0 +1,83 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import ShoeImage from './ShoeImage';
+import { mockData } from '../../data/MockData';
+
+const mockShoe = mockData.men[0];
+const images = mockShoe.colorImages['Red'];
+
+describe('ShoeImage', () => {
+  it('renders the first image by default', () => {
+    render(
+      <ShoeImage images={images} name={mockShoe.name} activeColor="Red" />
+    );
+    const image = screen.getByRole('img') as HTMLImageElement;
+    expect(image).toBeInTheDocument();
+    expect(image.src).toContain(images[0]);
+  });
+
+  it('renders nav buttons if more than 1 image', () => {
+    render(
+      <ShoeImage images={images} name={mockShoe.name} activeColor="Red" />
+    );
+    expect(screen.getByText('‹')).toBeInTheDocument();
+    expect(screen.getByText('›')).toBeInTheDocument();
+  });
+
+  it('does not render nav buttons if only 1 image', () => {
+    render(
+      <ShoeImage
+        images={mockShoe.colorImages['Black']}
+        name={mockShoe.name}
+        activeColor="Black"
+      />
+    );
+    expect(screen.queryByText('‹')).not.toBeInTheDocument();
+    expect(screen.queryByText('›')).not.toBeInTheDocument();
+  });
+
+  it('clicking next shows the next image', () => {
+    render(
+      <ShoeImage images={images} name={mockShoe.name} activeColor="Red" />
+    );
+    const image = screen.getByRole('img') as HTMLImageElement;
+
+    expect(image.src).toContain(images[0]);
+
+    fireEvent.click(screen.getByText('›'));
+
+    expect(image.src).toContain(images[1]);
+  });
+
+  it('clicking prev wraps around to last image', () => {
+    render(
+      <ShoeImage images={images} name={mockShoe.name} activeColor="Red" />
+    );
+    const image = screen.getByRole('img') as HTMLImageElement;
+
+    expect(image.src).toContain(images[0]);
+
+    fireEvent.click(screen.getByText('‹'));
+
+    expect(image.src).toContain(images[images.length - 1]);
+  });
+
+  it('resets to index 0 when images prop changes', () => {
+    const { rerender } = render(
+      <ShoeImage images={images} name={mockShoe.name} activeColor="Red" />
+    );
+    const redImage = screen.getByRole('img') as HTMLImageElement;
+    expect(redImage.src).toContain(images[0]);
+
+    fireEvent.click(screen.getByText('›'));
+
+    expect(redImage.src).toContain(images[1]);
+
+    const newImages = mockShoe.colorImages['Black'];
+    rerender(
+      <ShoeImage images={newImages} name={mockShoe.name} activeColor="Black" />
+    );
+
+    const blackImage = screen.getByRole('img') as HTMLImageElement;
+    expect(blackImage.src).toContain(newImages[0]);
+  });
+});

--- a/src/components/ProductPages/ShoeImage.test.tsx
+++ b/src/components/ProductPages/ShoeImage.test.tsx
@@ -19,8 +19,7 @@ describe('ShoeImage', () => {
     render(
       <ShoeImage images={images} name={mockShoe.name} activeColor="Red" />
     );
-    expect(screen.getByText('‹')).toBeInTheDocument();
-    expect(screen.getByText('›')).toBeInTheDocument();
+    expect(screen.getAllByRole('button')).toHaveLength(2);
   });
 
   it('does not render nav buttons if only 1 image', () => {
@@ -31,8 +30,7 @@ describe('ShoeImage', () => {
         activeColor="Black"
       />
     );
-    expect(screen.queryByText('‹')).not.toBeInTheDocument();
-    expect(screen.queryByText('›')).not.toBeInTheDocument();
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
   });
 
   it('clicking next shows the next image', () => {

--- a/src/components/ProductPages/ShoeImage.tsx
+++ b/src/components/ProductPages/ShoeImage.tsx
@@ -1,24 +1,56 @@
+import { useState, useEffect } from 'react';
 import Image from 'next/image';
 
 interface ShoeImageProps {
-  activeImage: string;
+  images: string[];
   name: string;
   activeColor: string;
 }
 
-const ShoeImage: React.FC<ShoeImageProps> = ({
-  activeImage,
-  name,
-  activeColor,
-}) => {
+const ShoeImage: React.FC<ShoeImageProps> = ({ images, name, activeColor }) => {
+  const [currentIndex, setCurrentIndex] = useState(0);
+
+  useEffect(() => {
+    setCurrentIndex(0);
+  }, [images]);
+
+  const nextImage = () => {
+    setCurrentIndex((prev) => (prev + 1) % images.length);
+  };
+
+  const prevImage = () => {
+    setCurrentIndex((prev) => (prev - 1 + images.length) % images.length);
+  };
+
   return (
-    <Image
-      src={activeImage}
-      alt={`${name} - ${activeColor}`}
-      className="w-full h-48 object-cover"
-      width={200}
-      height={200}
-    />
+    <div className="relative w-full h-60 group">
+      {images.length > 0 && currentIndex < images.length && (
+        <Image
+          src={images[currentIndex]}
+          alt={`${name} - ${activeColor}`}
+          width={300}
+          height={300}
+          className="w-full h-60 object-cover rounded transition-all duration-300 ease-in-out z-0"
+        />
+      )}
+
+      {images.length > 1 && (
+        <>
+          <button
+            onClick={prevImage}
+            className="absolute left-0 top-0 h-full w-1/2 flex items-center justify-start pl-4 text-white text-2xl transition group-hover:flex"
+          >
+            ‹
+          </button>
+          <button
+            onClick={nextImage}
+            className="absolute right-0 top-0 h-full w-1/2 flex items-center justify-end pr-4 text-white text-2xl transition group-hover:flex"
+          >
+            ›
+          </button>
+        </>
+      )}
+    </div>
   );
 };
 

--- a/src/components/ProductPages/ShoeImage.tsx
+++ b/src/components/ProductPages/ShoeImage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import Image from 'next/image';
 
 interface ShoeImageProps {
@@ -8,25 +8,28 @@ interface ShoeImageProps {
 }
 
 const ShoeImage: React.FC<ShoeImageProps> = ({ images, name, activeColor }) => {
-  const [currentIndex, setCurrentIndex] = useState(0);
-
+  const [image, setImage] = useState('');
+  const indexRef = useRef(0);
   useEffect(() => {
-    setCurrentIndex(0);
+    indexRef.current = 0;
+    setImage(images[indexRef.current]);
   }, [images]);
 
   const nextImage = () => {
-    setCurrentIndex((prev) => (prev + 1) % images.length);
+    indexRef.current = (indexRef.current + 1) % images.length;
+    setImage(images[indexRef.current]);
   };
 
   const prevImage = () => {
-    setCurrentIndex((prev) => (prev - 1 + images.length) % images.length);
+    indexRef.current = (indexRef.current - 1 + images.length) % images.length;
+    setImage(images[indexRef.current]);
   };
 
   return (
     <div className="relative w-full h-60 group">
-      {images.length > 0 && currentIndex < images.length && (
+      {image.length > 0 && (
         <Image
-          src={images[currentIndex]}
+          src={image}
           alt={`${name} - ${activeColor}`}
           width={300}
           height={300}

--- a/src/data/MockData.ts
+++ b/src/data/MockData.ts
@@ -12,10 +12,17 @@ export const mockData: { [key: string]: Shoe[] } = {
       description:
         'The Nike Air Max 97 Kids sneaker offers a stylish design with air cushioning for all-day comfort.',
       colorImages: {
-        Pink: 'https://cdn.thewirecutter.com/wp-content/media/2024/05/white-sneaker-2048px-9338.jpg?auto=webp&quality=75&width=1024',
-        Blue: 'https://cdn.thewirecutter.com/wp-content/media/2024/05/white-sneaker-2048px-9358.jpg?auto=webp&quality=75&width=480&dpr=1.5',
-        White:
+        Pink: [
           'https://cdn.thewirecutter.com/wp-content/media/2024/05/white-sneaker-2048px-9338.jpg?auto=webp&quality=75&width=1024',
+          'https://cdn.thewirecutter.com/wp-content/media/2024/05/white-sneaker-2048px-9358.jpg?auto=webp&quality=75&width=480&dpr=1.5',
+        ],
+        Blue: [
+          'https://cdn.thewirecutter.com/wp-content/media/2024/05/white-sneaker-2048px-9358.jpg?auto=webp&quality=75&width=480&dpr=1.5',
+        ],
+        White: [
+          'https://cdn.thewirecutter.com/wp-content/media/2024/05/white-sneaker-2048px-9338.jpg?auto=webp&quality=75&width=1024',
+          'https://cdn.thewirecutter.com/wp-content/media/2024/05/white-sneaker-2048px-9358.jpg?auto=webp&quality=75&width=480&dpr=1.5',
+        ],
       },
       prices: {
         Pink: 90,
@@ -33,11 +40,17 @@ export const mockData: { [key: string]: Shoe[] } = {
       description:
         'The Adidas UltraBoost 21 Kids shoe is designed for comfort with superior energy return, perfect for active kids.',
       colorImages: {
-        Pink: 'https://cdn.thewirecutter.com/wp-content/media/2024/05/white-sneaker-2048px-9358.jpg?auto=webp&quality=75&width=480&dpr=1.5',
-        White:
+        Pink: [
+          'https://cdn.thewirecutter.com/wp-content/media/2024/05/white-sneaker-2048px-9358.jpg?auto=webp&quality=75&width=480&dpr=1.5',
           'https://cdn.thewirecutter.com/wp-content/media/2024/05/white-sneaker-2048px-9338.jpg?auto=webp&quality=75&width=1024',
-        Yellow:
+        ],
+        White: [
           'https://cdn.thewirecutter.com/wp-content/media/2024/05/white-sneaker-2048px-9338.jpg?auto=webp&quality=75&width=1024',
+          'https://cdn.thewirecutter.com/wp-content/media/2024/05/white-sneaker-2048px-9358.jpg?auto=webp&quality=75&width=480&dpr=1.5',
+        ],
+        Yellow: [
+          'https://cdn.thewirecutter.com/wp-content/media/2024/05/white-sneaker-2048px-9338.jpg?auto=webp&quality=75&width=1024',
+        ],
       },
       prices: {
         Pink: 75,
@@ -55,10 +68,16 @@ export const mockData: { [key: string]: Shoe[] } = {
       description:
         'The Yeezy Boost 350 V2 Kids sneaker combines comfort with style, offering a trendy design and ultimate comfort.',
       colorImages: {
-        Red: 'https://cdn.thewirecutter.com/wp-content/media/2024/05/white-sneaker-2048px-9338.jpg?auto=webp&quality=75&width=1024',
-        Black:
+        Red: [
+          'https://cdn.thewirecutter.com/wp-content/media/2024/05/white-sneaker-2048px-9338.jpg?auto=webp&quality=75&width=1024',
+        ],
+        Black: [
           'https://cdn.thewirecutter.com/wp-content/media/2024/05/white-sneaker-2048px-9358.jpg?auto=webp&quality=75&width=480&dpr=1.5',
-        Blue: 'https://cdn.thewirecutter.com/wp-content/media/2024/05/white-sneaker-2048px-9338.jpg?auto=webp&quality=75&width=1024',
+          'https://cdn.thewirecutter.com/wp-content/media/2024/05/white-sneaker-2048px-9338.jpg?auto=webp&quality=75&width=1024',
+        ],
+        Blue: [
+          'https://cdn.thewirecutter.com/wp-content/media/2024/05/white-sneaker-2048px-9338.jpg?auto=webp&quality=75&width=1024',
+        ],
       },
       prices: {
         Red: 100,
@@ -76,9 +95,13 @@ export const mockData: { [key: string]: Shoe[] } = {
       description:
         'The Reebok Classic Leather Kids sneaker is a timeless design with comfort and style for any occasion.',
       colorImages: {
-        White:
+        White: [
           'https://cdn.thewirecutter.com/wp-content/media/2024/05/white-sneaker-2048px-9358.jpg?auto=webp&quality=75&width=480&dpr=1.5',
-        Pink: 'https://cdn.thewirecutter.com/wp-content/media/2024/05/white-sneaker-2048px-9338.jpg?auto=webp&quality=75&width=1024',
+          'https://cdn.thewirecutter.com/wp-content/media/2024/05/white-sneaker-2048px-9338.jpg?auto=webp&quality=75&width=1024',
+        ],
+        Pink: [
+          'https://cdn.thewirecutter.com/wp-content/media/2024/05/white-sneaker-2048px-9338.jpg?auto=webp&quality=75&width=1024',
+        ],
       },
       prices: {
         White: 50,
@@ -95,15 +118,23 @@ export const mockData: { [key: string]: Shoe[] } = {
       description:
         'The iconic Converse Chuck Taylor All Star Kids sneaker blends retro style with all-day comfort for young feet.',
       colorImages: {
-        Red: 'https://cdn.thewirecutter.com/wp-content/media/2024/05/white-sneaker-2048px-9338.jpg?auto=webp&quality=75&width=1024',
-        Blue: 'https://cdn.thewirecutter.com/wp-content/media/2024/05/white-sneaker-2048px-9358.jpg?auto=webp&quality=75&width=480&dpr=1.5',
-        White:
+        Red: [
           'https://cdn.thewirecutter.com/wp-content/media/2024/05/white-sneaker-2048px-9338.jpg?auto=webp&quality=75&width=1024',
+          'https://cdn.thewirecutter.com/wp-content/media/2024/05/white-sneaker-2048px-9358.jpg?auto=webp&quality=75&width=480&dpr=1.5',
+        ],
+        Blue: [
+          'https://cdn.thewirecutter.com/wp-content/media/2024/05/white-sneaker-2048px-9338.jpg?auto=webp&quality=75&width=1024',
+          'https://cdn.thewirecutter.com/wp-content/media/2024/05/white-sneaker-2048px-9358.jpg?auto=webp&quality=75&width=480&dpr=1.5',
+        ],
+        White: [
+          'https://cdn.thewirecutter.com/wp-content/media/2024/05/white-sneaker-2048px-9338.jpg?auto=webp&quality=75&width=1024',
+          'https://cdn.thewirecutter.com/wp-content/media/2024/05/white-sneaker-2048px-9358.jpg?auto=webp&quality=75&width=480&dpr=1.5',
+        ],
       },
       prices: {
         Red: 45,
-        Blue: 40,
-        White: 35,
+        Blue: 45,
+        White: 50,
       },
     },
     {
@@ -116,10 +147,13 @@ export const mockData: { [key: string]: Shoe[] } = {
       description:
         "The Nike Zoom Freak 1 Kids sneaker is Giannis Antetokounmpo's signature basketball shoe, now for younger athletes.",
       colorImages: {
-        Orange:
+        Orange: [
           'https://cdn.thewirecutter.com/wp-content/media/2024/05/white-sneaker-2048px-9358.jpg?auto=webp&quality=75&width=480&dpr=1.5',
-        Green:
+        ],
+        Green: [
           'https://cdn.thewirecutter.com/wp-content/media/2024/05/white-sneaker-2048px-9338.jpg?auto=webp&quality=75&width=1024',
+          'https://cdn.thewirecutter.com/wp-content/media/2024/05/white-sneaker-2048px-9358.jpg?auto=webp&quality=75&width=480&dpr=1.5',
+        ],
       },
       prices: {
         Orange: 50,
@@ -136,8 +170,14 @@ export const mockData: { [key: string]: Shoe[] } = {
       description:
         'The New Balance Fresh Foam 1080v11 Kids sneaker provides the ultimate in comfort and support for active kids.',
       colorImages: {
-        Blue: 'https://cdn.thewirecutter.com/wp-content/media/2024/05/white-sneaker-2048px-9338.jpg?auto=webp&quality=75&width=1024',
-        Pink: 'https://cdn.thewirecutter.com/wp-content/media/2024/05/white-sneaker-2048px-9358.jpg?auto=webp&quality=75&width=480&dpr=1.5',
+        Blue: [
+          'https://cdn.thewirecutter.com/wp-content/media/2024/05/white-sneaker-2048px-9338.jpg?auto=webp&quality=75&width=1024',
+          'https://cdn.thewirecutter.com/wp-content/media/2024/05/white-sneaker-2048px-9358.jpg?auto=webp&quality=75&width=480&dpr=1.5',
+        ],
+        Pink: [
+          'https://cdn.thewirecutter.com/wp-content/media/2024/05/white-sneaker-2048px-9358.jpg?auto=webp&quality=75&width=480&dpr=1.5',
+          'https://cdn.thewirecutter.com/wp-content/media/2024/05/white-sneaker-2048px-9338.jpg?auto=webp&quality=75&width=1024',
+        ],
       },
       prices: {
         Blue: 55,
@@ -154,10 +194,13 @@ export const mockData: { [key: string]: Shoe[] } = {
       description:
         'The Nike Mamba Fury Kids sneaker celebrates the legacy of Kobe Bryant with a durable and stylish design.',
       colorImages: {
-        Black:
+        Black: [
           'https://cdn.thewirecutter.com/wp-content/media/2024/05/white-sneaker-2048px-9358.jpg?auto=webp&quality=75&width=480&dpr=1.5',
-        Yellow:
           'https://cdn.thewirecutter.com/wp-content/media/2024/05/white-sneaker-2048px-9338.jpg?auto=webp&quality=75&width=1024',
+        ],
+        Yellow: [
+          'https://cdn.thewirecutter.com/wp-content/media/2024/05/white-sneaker-2048px-9338.jpg?auto=webp&quality=75&width=1024',
+        ],
       },
       prices: {
         Black: 60,
@@ -176,11 +219,17 @@ export const mockData: { [key: string]: Shoe[] } = {
       description:
         'The Nike Air Max 97 is a classic sneaker with air cushioning and a sleek design.',
       colorImages: {
-        Red: 'https://cdn.thewirecutter.com/wp-content/media/2024/05/white-sneaker-2048px-9338.jpg?auto=webp&quality=75&width=1024',
-        Black:
-          'https://cdn.thewirecutter.com/wp-content/media/2024/05/white-sneaker-2048px-9358.jpg?auto=webp&quality=75&width=480&dpr=1.5',
-        White:
+        Red: [
           'https://cdn.thewirecutter.com/wp-content/media/2024/05/white-sneaker-2048px-9338.jpg?auto=webp&quality=75&width=1024',
+          'https://cdn.thewirecutter.com/wp-content/media/2024/05/white-sneaker-2048px-9358.jpg?auto=webp&quality=75&width=480&dpr=1.5',
+        ],
+        Black: [
+          'https://cdn.thewirecutter.com/wp-content/media/2024/05/white-sneaker-2048px-9358.jpg?auto=webp&quality=75&width=480&dpr=1.5',
+        ],
+        White: [
+          'https://cdn.thewirecutter.com/wp-content/media/2024/05/white-sneaker-2048px-9338.jpg?auto=webp&quality=75&width=1024',
+          'https://cdn.thewirecutter.com/wp-content/media/2024/05/white-sneaker-2048px-9358.jpg?auto=webp&quality=75&width=480&dpr=1.5',
+        ],
       },
       prices: {
         Red: 150,
@@ -198,11 +247,17 @@ export const mockData: { [key: string]: Shoe[] } = {
       description:
         'The Adidas UltraBoost 21 offers superior comfort and energy return with every step.',
       colorImages: {
-        Blue: 'https://cdn.thewirecutter.com/wp-content/media/2024/05/white-sneaker-2048px-9358.jpg?auto=webp&quality=75&width=480&dpr=1.5',
-        White:
-          'https://cdn.thewirecutter.com/wp-content/media/2024/05/white-sneaker-2048px-9338.jpg?auto=webp&quality=75&width=1024',
-        Black:
+        Blue: [
           'https://cdn.thewirecutter.com/wp-content/media/2024/05/white-sneaker-2048px-9358.jpg?auto=webp&quality=75&width=480&dpr=1.5',
+          'https://cdn.thewirecutter.com/wp-content/media/2024/05/white-sneaker-2048px-9338.jpg?auto=webp&quality=75&width=1024',
+        ],
+        White: [
+          'https://cdn.thewirecutter.com/wp-content/media/2024/05/white-sneaker-2048px-9338.jpg?auto=webp&quality=75&width=1024',
+        ],
+        Black: [
+          'https://cdn.thewirecutter.com/wp-content/media/2024/05/white-sneaker-2048px-9358.jpg?auto=webp&quality=75&width=480&dpr=1.5',
+          'https://cdn.thewirecutter.com/wp-content/media/2024/05/white-sneaker-2048px-9338.jpg?auto=webp&quality=75&width=1024',
+        ],
       },
       prices: {
         Blue: 180,
@@ -220,11 +275,17 @@ export const mockData: { [key: string]: Shoe[] } = {
       description:
         'The Yeezy Boost 350 V2 features a stylish design and comfortable boost cushioning.',
       colorImages: {
-        Grey: 'https://cdn.thewirecutter.com/wp-content/media/2024/05/white-sneaker-2048px-9338.jpg?auto=webp&quality=75&width=1024',
-        Black:
-          'https://cdn.thewirecutter.com/wp-content/media/2024/05/white-sneaker-2048px-9358.jpg?auto=webp&quality=75&width=480&dpr=1.5',
-        White:
+        Grey: [
           'https://cdn.thewirecutter.com/wp-content/media/2024/05/white-sneaker-2048px-9338.jpg?auto=webp&quality=75&width=1024',
+        ],
+        Black: [
+          'https://cdn.thewirecutter.com/wp-content/media/2024/05/white-sneaker-2048px-9358.jpg?auto=webp&quality=75&width=480&dpr=1.5',
+          'https://cdn.thewirecutter.com/wp-content/media/2024/05/white-sneaker-2048px-9338.jpg?auto=webp&quality=75&width=1024',
+        ],
+        White: [
+          'https://cdn.thewirecutter.com/wp-content/media/2024/05/white-sneaker-2048px-9338.jpg?auto=webp&quality=75&width=1024',
+          'https://cdn.thewirecutter.com/wp-content/media/2024/05/white-sneaker-2048px-9358.jpg?auto=webp&quality=75&width=480&dpr=1.5',
+        ],
       },
       prices: {
         Grey: 220,
@@ -242,10 +303,13 @@ export const mockData: { [key: string]: Shoe[] } = {
       description:
         'The Reebok Classic Leather is a versatile sneaker that blends comfort with style.',
       colorImages: {
-        White:
+        White: [
           'https://cdn.thewirecutter.com/wp-content/media/2024/05/white-sneaker-2048px-9358.jpg?auto=webp&quality=75&width=480&dpr=1.5',
-        Black:
+        ],
+        Black: [
           'https://cdn.thewirecutter.com/wp-content/media/2024/05/white-sneaker-2048px-9338.jpg?auto=webp&quality=75&width=1024',
+          'https://cdn.thewirecutter.com/wp-content/media/2024/05/white-sneaker-2048px-9358.jpg?auto=webp&quality=75&width=480&dpr=1.5',
+        ],
       },
       prices: {
         White: 90,
@@ -262,12 +326,20 @@ export const mockData: { [key: string]: Shoe[] } = {
       description:
         'The iconic Converse Chuck Taylor All Star has stood the test of time.',
       colorImages: {
-        Red: 'https://cdn.thewirecutter.com/wp-content/media/2024/05/white-sneaker-2048px-9338.jpg?auto=webp&quality=75&width=1024',
-        Black:
-          'https://cdn.thewirecutter.com/wp-content/media/2024/05/white-sneaker-2048px-9358.jpg?auto=webp&quality=75&width=480&dpr=1.5',
-        White:
+        Red: [
           'https://cdn.thewirecutter.com/wp-content/media/2024/05/white-sneaker-2048px-9338.jpg?auto=webp&quality=75&width=1024',
-        Blue: 'https://cdn.thewirecutter.com/wp-content/media/2024/05/white-sneaker-2048px-9358.jpg?auto=webp&quality=75&width=480&dpr=1.5',
+          'https://cdn.thewirecutter.com/wp-content/media/2024/05/white-sneaker-2048px-9358.jpg?auto=webp&quality=75&width=480&dpr=1.5',
+        ],
+        Black: [
+          'https://cdn.thewirecutter.com/wp-content/media/2024/05/white-sneaker-2048px-9358.jpg?auto=webp&quality=75&width=480&dpr=1.5',
+        ],
+        White: [
+          'https://cdn.thewirecutter.com/wp-content/media/2024/05/white-sneaker-2048px-9338.jpg?auto=webp&quality=75&width=1024',
+        ],
+        Blue: [
+          'https://cdn.thewirecutter.com/wp-content/media/2024/05/white-sneaker-2048px-9358.jpg?auto=webp&quality=75&width=480&dpr=1.5',
+          'https://cdn.thewirecutter.com/wp-content/media/2024/05/white-sneaker-2048px-9338.jpg?auto=webp&quality=75&width=1024',
+        ],
       },
       prices: {
         Red: 60,
@@ -278,7 +350,7 @@ export const mockData: { [key: string]: Shoe[] } = {
     },
     {
       picture_url:
-        'https://cdn.thewirecutter.com/wp-content/media/2024/05/white-sneaker-2048px-9473-2.jpg?auto=webp&quality=75&width=980&dpr=2',
+        'https://cdn.thewirecutter.com/wp-content/media/2024/05/white-sneaker-2048px-9477-2.jpg?auto=webp&quality=75&width=980&dpr=2',
       name: 'Nike Zoom Freak 1',
       brand: 'Nike',
       sizes: ['9', '10', '11', '12'],
@@ -286,10 +358,12 @@ export const mockData: { [key: string]: Shoe[] } = {
       description:
         "The Nike Zoom Freak 1 is Giannis Antetokounmpo's signature basketball shoe.",
       colorImages: {
-        Orange:
+        Orange: [
           'https://cdn.thewirecutter.com/wp-content/media/2024/05/white-sneaker-2048px-9358.jpg?auto=webp&quality=75&width=480&dpr=1.5',
-        Black:
+        ],
+        Black: [
           'https://cdn.thewirecutter.com/wp-content/media/2024/05/white-sneaker-2048px-9338.jpg?auto=webp&quality=75&width=1024',
+        ],
       },
       prices: {
         Orange: 120,
@@ -306,8 +380,14 @@ export const mockData: { [key: string]: Shoe[] } = {
       description:
         'The New Balance Fresh Foam 1080v11 provides premium comfort and support.',
       colorImages: {
-        Grey: 'https://cdn.thewirecutter.com/wp-content/media/2024/05/white-sneaker-2048px-9338.jpg?auto=webp&quality=75&width=1024',
-        Blue: 'https://cdn.thewirecutter.com/wp-content/media/2024/05/white-sneaker-2048px-9358.jpg?auto=webp&quality=75&width=480&dpr=1.5',
+        Grey: [
+          'https://cdn.thewirecutter.com/wp-content/media/2024/05/white-sneaker-2048px-9338.jpg?auto=webp&quality=75&width=1024',
+          'https://cdn.thewirecutter.com/wp-content/media/2024/05/white-sneaker-2048px-9358.jpg?auto=webp&quality=75&width=480&dpr=1.5',
+        ],
+        Blue: [
+          'https://cdn.thewirecutter.com/wp-content/media/2024/05/white-sneaker-2048px-9358.jpg?auto=webp&quality=75&width=480&dpr=1.5',
+          'https://cdn.thewirecutter.com/wp-content/media/2024/05/white-sneaker-2048px-9338.jpg?auto=webp&quality=75&width=1024',
+        ],
       },
       prices: {
         Grey: 140,
@@ -324,10 +404,14 @@ export const mockData: { [key: string]: Shoe[] } = {
       description:
         'The Nike Mamba Fury is a basketball shoe that celebrates the legacy of Kobe Bryant.',
       colorImages: {
-        Black:
+        Black: [
           'https://cdn.thewirecutter.com/wp-content/media/2024/05/white-sneaker-2048px-9358.jpg?auto=webp&quality=75&width=480&dpr=1.5',
-        Yellow:
           'https://cdn.thewirecutter.com/wp-content/media/2024/05/white-sneaker-2048px-9338.jpg?auto=webp&quality=75&width=1024',
+        ],
+        Yellow: [
+          'https://cdn.thewirecutter.com/wp-content/media/2024/05/white-sneaker-2048px-9338.jpg?auto=webp&quality=75&width=1024',
+          'https://cdn.thewirecutter.com/wp-content/media/2024/05/white-sneaker-2048px-9358.jpg?auto=webp&quality=75&width=480&dpr=1.5',
+        ],
       },
       prices: {
         Black: 110,
@@ -346,11 +430,16 @@ export const mockData: { [key: string]: Shoe[] } = {
       description:
         "The Nike Air Max 97 Women's is a stylish sneaker with air cushioning for all-day comfort.",
       colorImages: {
-        Pink: 'https://cdn.thewirecutter.com/wp-content/media/2024/05/white-sneaker-2048px-9393.jpg?auto=webp&quality=75&width=980&dpr=2',
-        Black:
-          'https://cdn.thewirecutter.com/wp-content/media/2024/05/white-sneaker-2048px-9405.jpg?auto=webp&quality=75&width=980&dpr=2',
-        White:
-          'https://cdn.thewirecutter.com/wp-content/media/2024/05/white-sneaker-2048px-9393.jpg?auto=webp&quality=75&width=980&dpr=2',
+        Pink: [
+          'https://cdn.thewirecutter.com/wp-content/media/2024/05/white-sneaker-2048px-9338.jpg?auto=webp&quality=75&width=1024',
+        ],
+        Black: [
+          'https://cdn.thewirecutter.com/wp-content/media/2024/05/white-sneaker-2048px-9358.jpg?auto=webp&quality=75&width=480&dpr=1.5',
+        ],
+        White: [
+          'https://cdn.thewirecutter.com/wp-content/media/2024/05/white-sneaker-2048px-9338.jpg?auto=webp&quality=75&width=1024',
+          'https://cdn.thewirecutter.com/wp-content/media/2024/05/white-sneaker-2048px-9358.jpg?auto=webp&quality=75&width=480&dpr=1.5',
+        ],
       },
       prices: {
         Pink: 150,
@@ -368,10 +457,17 @@ export const mockData: { [key: string]: Shoe[] } = {
       description:
         "The Adidas UltraBoost 21 Women's sneaker offers superior comfort and energy return with every step.",
       colorImages: {
-        Pink: 'https://cdn.thewirecutter.com/wp-content/media/2024/05/white-sneaker-2048px-9405.jpg?auto=webp&quality=75&width=980&dpr=2',
-        White:
-          'https://cdn.thewirecutter.com/wp-content/media/2024/05/white-sneaker-2048px-9393.jpg?auto=webp&quality=75&width=980&dpr=2',
-        Grey: 'https://cdn.thewirecutter.com/wp-content/media/2024/05/white-sneaker-2048px-9405.jpg?auto=webp&quality=75&width=980&dpr=2',
+        Pink: [
+          'https://cdn.thewirecutter.com/wp-content/media/2024/05/white-sneaker-2048px-9358.jpg?auto=webp&quality=75&width=480&dpr=1.5',
+          'https://cdn.thewirecutter.com/wp-content/media/2024/05/white-sneaker-2048px-9338.jpg?auto=webp&quality=75&width=1024',
+        ],
+        White: [
+          'https://cdn.thewirecutter.com/wp-content/media/2024/05/white-sneaker-2048px-9338.jpg?auto=webp&quality=75&width=1024',
+        ],
+        Grey: [
+          'https://cdn.thewirecutter.com/wp-content/media/2024/05/white-sneaker-2048px-9358.jpg?auto=webp&quality=75&width=480&dpr=1.5',
+          'https://cdn.thewirecutter.com/wp-content/media/2024/05/white-sneaker-2048px-9338.jpg?auto=webp&quality=75&width=1024',
+        ],
       },
       prices: {
         Pink: 180,
@@ -389,12 +485,17 @@ export const mockData: { [key: string]: Shoe[] } = {
       description:
         "The Yeezy Boost 350 V2 Women's features a modern design and comfortable boost cushioning for all-day wear.",
       colorImages: {
-        Beige:
-          'https://cdn.thewirecutter.com/wp-content/media/2024/05/white-sneaker-2048px-9393.jpg?auto=webp&quality=75&width=980&dpr=2',
-        Black:
-          'https://cdn.thewirecutter.com/wp-content/media/2024/05/white-sneaker-2048px-9405.jpg?auto=webp&quality=75&width=980&dpr=2',
-        White:
-          'https://cdn.thewirecutter.com/wp-content/media/2024/05/white-sneaker-2048px-9393.jpg?auto=webp&quality=75&width=980&dpr=2',
+        Beige: [
+          'https://cdn.thewirecutter.com/wp-content/media/2024/05/white-sneaker-2048px-9338.jpg?auto=webp&quality=75&width=1024',
+          'https://cdn.thewirecutter.com/wp-content/media/2024/05/white-sneaker-2048px-9358.jpg?auto=webp&quality=75&width=480&dpr=1.5',
+        ],
+        Black: [
+          'https://cdn.thewirecutter.com/wp-content/media/2024/05/white-sneaker-2048px-9358.jpg?auto=webp&quality=75&width=480&dpr=1.5',
+          'https://cdn.thewirecutter.com/wp-content/media/2024/05/white-sneaker-2048px-9338.jpg?auto=webp&quality=75&width=1024',
+        ],
+        White: [
+          'https://cdn.thewirecutter.com/wp-content/media/2024/05/white-sneaker-2048px-9338.jpg?auto=webp&quality=75&width=1024',
+        ],
       },
       prices: {
         Beige: 220,
@@ -412,10 +513,13 @@ export const mockData: { [key: string]: Shoe[] } = {
       description:
         "The Reebok Classic Leather Women's sneaker offers a blend of comfort, style, and durability.",
       colorImages: {
-        White:
-          'https://cdn.thewirecutter.com/wp-content/media/2024/05/white-sneaker-2048px-9405.jpg?auto=webp&quality=75&width=980&dpr=2',
-        Black:
-          'https://cdn.thewirecutter.com/wp-content/media/2024/05/white-sneaker-2048px-9393.jpg?auto=webp&quality=75&width=980&dpr=2',
+        White: [
+          'https://cdn.thewirecutter.com/wp-content/media/2024/05/white-sneaker-2048px-9358.jpg?auto=webp&quality=75&width=480&dpr=1.5',
+          'https://cdn.thewirecutter.com/wp-content/media/2024/05/white-sneaker-2048px-9338.jpg?auto=webp&quality=75&width=1024',
+        ],
+        Black: [
+          'https://cdn.thewirecutter.com/wp-content/media/2024/05/white-sneaker-2048px-9338.jpg?auto=webp&quality=75&width=1024',
+        ],
       },
       prices: {
         White: 90,
@@ -432,12 +536,20 @@ export const mockData: { [key: string]: Shoe[] } = {
       description:
         "The Converse Chuck Taylor All Star Women's is a timeless classic with a variety of colors.",
       colorImages: {
-        Red: 'https://cdn.thewirecutter.com/wp-content/media/2024/05/white-sneaker-2048px-9393.jpg?auto=webp&quality=75&width=980&dpr=2',
-        Black:
-          'https://cdn.thewirecutter.com/wp-content/media/2024/05/white-sneaker-2048px-9405.jpg?auto=webp&quality=75&width=980&dpr=2',
-        White:
-          'https://cdn.thewirecutter.com/wp-content/media/2024/05/white-sneaker-2048px-9393.jpg?auto=webp&quality=75&width=980&dpr=2',
-        Blue: 'https://cdn.thewirecutter.com/wp-content/media/2024/05/white-sneaker-2048px-9405.jpg?auto=webp&quality=75&width=980&dpr=2',
+        Red: [
+          'https://cdn.thewirecutter.com/wp-content/media/2024/05/white-sneaker-2048px-9338.jpg?auto=webp&quality=75&width=1024',
+        ],
+        Black: [
+          'https://cdn.thewirecutter.com/wp-content/media/2024/05/white-sneaker-2048px-9358.jpg?auto=webp&quality=75&width=480&dpr=1.5',
+        ],
+        White: [
+          'https://cdn.thewirecutter.com/wp-content/media/2024/05/white-sneaker-2048px-9338.jpg?auto=webp&quality=75&width=1024',
+          'https://cdn.thewirecutter.com/wp-content/media/2024/05/white-sneaker-2048px-9358.jpg?auto=webp&quality=75&width=480&dpr=1.5',
+        ],
+        Blue: [
+          'https://cdn.thewirecutter.com/wp-content/media/2024/05/white-sneaker-2048px-9358.jpg?auto=webp&quality=75&width=480&dpr=1.5',
+          'https://cdn.thewirecutter.com/wp-content/media/2024/05/white-sneaker-2048px-9338.jpg?auto=webp&quality=75&width=1024',
+        ],
       },
       prices: {
         Red: 60,
@@ -456,10 +568,13 @@ export const mockData: { [key: string]: Shoe[] } = {
       description:
         "The Nike Zoom Freak 1 Women's is Giannis Antetokounmpo's signature basketball shoe, designed for women.",
       colorImages: {
-        Orange:
-          'https://cdn.thewirecutter.com/wp-content/media/2024/05/white-sneaker-2048px-9405.jpg?auto=webp&quality=75&width=980&dpr=2',
-        Black:
-          'https://cdn.thewirecutter.com/wp-content/media/2024/05/white-sneaker-2048px-9393.jpg?auto=webp&quality=75&width=980&dpr=2',
+        Orange: [
+          'https://cdn.thewirecutter.com/wp-content/media/2024/05/white-sneaker-2048px-9358.jpg?auto=webp&quality=75&width=480&dpr=1.5',
+          'https://cdn.thewirecutter.com/wp-content/media/2024/05/white-sneaker-2048px-9338.jpg?auto=webp&quality=75&width=1024',
+        ],
+        Black: [
+          'https://cdn.thewirecutter.com/wp-content/media/2024/05/white-sneaker-2048px-9338.jpg?auto=webp&quality=75&width=1024',
+        ],
       },
       prices: {
         Orange: 120,
@@ -476,8 +591,13 @@ export const mockData: { [key: string]: Shoe[] } = {
       description:
         "The New Balance Fresh Foam 1080v11 Women's offers plush cushioning and premium comfort.",
       colorImages: {
-        Grey: 'https://cdn.thewirecutter.com/wp-content/media/2024/05/white-sneaker-2048px-9393.jpg?auto=webp&quality=75&width=980&dpr=2',
-        Blue: 'https://cdn.thewirecutter.com/wp-content/media/2024/05/white-sneaker-2048px-9405.jpg?auto=webp&quality=75&width=980&dpr=2',
+        Grey: [
+          'https://cdn.thewirecutter.com/wp-content/media/2024/05/white-sneaker-2048px-9338.jpg?auto=webp&quality=75&width=1024',
+          'https://cdn.thewirecutter.com/wp-content/media/2024/05/white-sneaker-2048px-9358.jpg?auto=webp&quality=75&width=480&dpr=1.5',
+        ],
+        Blue: [
+          'https://cdn.thewirecutter.com/wp-content/media/2024/05/white-sneaker-2048px-9358.jpg?auto=webp&quality=75&width=480&dpr=1.5',
+        ],
       },
       prices: {
         Grey: 140,
@@ -494,10 +614,13 @@ export const mockData: { [key: string]: Shoe[] } = {
       description:
         "The Nike Mamba Fury Women's pays tribute to Kobe Bryant and is designed for performance on the court.",
       colorImages: {
-        Black:
-          'https://cdn.thewirecutter.com/wp-content/media/2024/05/white-sneaker-2048px-9405.jpg?auto=webp&quality=75&width=980&dpr=2',
-        Yellow:
-          'https://cdn.thewirecutter.com/wp-content/media/2024/05/white-sneaker-2048px-9393.jpg?auto=webp&quality=75&width=980&dpr=2',
+        Black: [
+          'https://cdn.thewirecutter.com/wp-content/media/2024/05/white-sneaker-2048px-9358.jpg?auto=webp&quality=75&width=480&dpr=1.5',
+        ],
+        Yellow: [
+          'https://cdn.thewirecutter.com/wp-content/media/2024/05/white-sneaker-2048px-9338.jpg?auto=webp&quality=75&width=1024',
+          'https://cdn.thewirecutter.com/wp-content/media/2024/05/white-sneaker-2048px-9358.jpg?auto=webp&quality=75&width=480&dpr=1.5',
+        ],
       },
       prices: {
         Black: 110,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -10,7 +10,7 @@ export interface Shoe {
   brand: string;
   sizes: string[];
   colors: string[];
-  colorImages: { [color: string]: string };
+  colorImages: { [color: string]: string[] };
   description: string;
   prices: { [color: string]: number };
 }


### PR DESCRIPTION
Added a carousel option for shoes with multiple images of a color. if only one image exists, nothing changes, if more than 1, you can click through them. Slightly increased the size of the images as well. 

For the carousel, clicking on the right or left of the image goes forward and backwards. takes up the whole width of the image (for mobile users doing it with a thumb).

Before / After
![image](https://github.com/user-attachments/assets/7298ced0-9256-45a5-aad3-fd7ceecd2fb2)
