### PR TITLE
Checkout Summary.

### DIFF
--- a/jest.setup.tsx
+++ b/jest.setup.tsx
@@ -2,8 +2,19 @@ import '@testing-library/jest-dom';
 
 jest.mock('next/image', () => ({
   __esModule: true,
-  default: (props: React.ComponentProps<'img'>) => {
-    return <img {...props} />;
+  default: ({
+    fill,
+    alt,
+    ...props
+  }: React.ComponentProps<'img'> & { fill?: boolean }) => {
+    if (fill) {
+      return (
+        <div style={{ position: 'relative', width: '100%', height: '100%' }}>
+          <img {...props} alt={alt} />
+        </div>
+      );
+    }
+    return <img {...props} alt={alt} />;
   },
 }));
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,8 @@
       "name": "sneakpeak",
       "version": "0.1.0",
       "dependencies": {
+        "@stripe/react-stripe-js": "^3.6.0",
+        "@stripe/stripe-js": "^7.2.0",
         "@vercel/edge-config": "^1.4.0",
         "autoprefixer": "^10.4.21",
         "mobx": "^6.13.7",
@@ -15,7 +17,8 @@
         "next": "^15.2.3",
         "postcss": "^8.5.3",
         "react": "^19.0.0",
-        "react-dom": "^19.0.0"
+        "react-dom": "^19.0.0",
+        "stripe": "^18.0.0"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
@@ -1957,6 +1960,29 @@
         "@sinonjs/commons": "^3.0.0"
       }
     },
+    "node_modules/@stripe/react-stripe-js": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@stripe/react-stripe-js/-/react-stripe-js-3.6.0.tgz",
+      "integrity": "sha512-zEnaUmTOsu7zhl3RWbZ0l1dRiad+QIbcAYzQfF+yYelURJowhAwesRHKWH+qGAIBEpkO6/VCLFHhVLH9DtPlnw==",
+      "license": "MIT",
+      "dependencies": {
+        "prop-types": "^15.7.2"
+      },
+      "peerDependencies": {
+        "@stripe/stripe-js": ">=1.44.1 <8.0.0",
+        "react": ">=16.8.0 <20.0.0",
+        "react-dom": ">=16.8.0 <20.0.0"
+      }
+    },
+    "node_modules/@stripe/stripe-js": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@stripe/stripe-js/-/stripe-js-7.2.0.tgz",
+      "integrity": "sha512-BXlt6BsFE599yOATuz78FiW9z4SyipCH3j1SDyKWe/3OUBdhcOr/BWnBi1xrtcC2kfqrTJjgvfH2PTfMPRmbTw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.16"
+      }
+    },
     "node_modules/@swc/counter": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
@@ -2508,7 +2534,6 @@
       "version": "20.17.28",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.28.tgz",
       "integrity": "sha512-DHlH/fNL6Mho38jTy7/JT7sn2wnXI+wULR6PV4gy4VHLVvnrV/d3pHAMQHhc4gjdLmK2ZiPoMxzp6B3yRajLSQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.19.2"
@@ -3713,7 +3738,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -3727,7 +3751,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
       "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -4277,7 +4300,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
@@ -4437,7 +4459,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -4447,7 +4468,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -4485,7 +4505,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
       "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -5324,7 +5343,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -5385,7 +5403,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -5420,7 +5437,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.1",
@@ -5543,7 +5559,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -5622,7 +5637,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -5651,7 +5665,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -7330,7 +7343,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -7813,7 +7825,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
@@ -7880,7 +7891,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -8188,7 +8198,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -8198,7 +8207,6 @@
       "version": "1.13.4",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
       "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -8756,7 +8764,6 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.4.0",
@@ -8768,7 +8775,6 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/psl": {
@@ -8810,6 +8816,21 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/qs": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
+      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/querystringify": {
       "version": "2.2.0",
@@ -9269,7 +9290,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
       "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -9289,7 +9309,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
       "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -9306,7 +9325,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
       "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -9325,7 +9343,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
       "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -9663,6 +9680,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/stripe": {
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/stripe/-/stripe-18.0.0.tgz",
+      "integrity": "sha512-3Fs33IzKUby//9kCkCa1uRpinAoTvj6rJgQ2jrBEysoxEvfsclvXdna1amyEYbA2EKkjynuB4+L/kleCCaWTpA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": ">=8.1.0",
+        "qs": "^6.11.0"
+      },
+      "engines": {
+        "node": ">=12.*"
       }
     },
     "node_modules/styled-jsx": {
@@ -10116,7 +10146,6 @@
       "version": "6.19.8",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
       "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/universalify": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
     "format": "prettier --write ."
   },
   "dependencies": {
+    "@stripe/react-stripe-js": "^3.6.0",
+    "@stripe/stripe-js": "^7.2.0",
     "@vercel/edge-config": "^1.4.0",
     "autoprefixer": "^10.4.21",
     "mobx": "^6.13.7",
@@ -20,7 +22,8 @@
     "next": "^15.2.3",
     "postcss": "^8.5.3",
     "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react-dom": "^19.0.0",
+    "stripe": "^18.0.0"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/src/app/checkout/page.tsx
+++ b/src/app/checkout/page.tsx
@@ -1,0 +1,16 @@
+import CheckoutSummary from '../../components/Checkout/CheckoutSummary';
+
+const CheckoutPage: React.FC = () => {
+  return (
+    <>
+      <div className="max-w-6xl mx-auto px-4 py-8 grid grid-cols-1 lg:grid-cols-3 gap-8">
+        <div className="lg:col-span-2">FORMS AND SUCH WILL BE HERE</div>
+        <div className="self-start">
+          <CheckoutSummary />
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default CheckoutPage;

--- a/src/app/checkout/page.tsx
+++ b/src/app/checkout/page.tsx
@@ -4,8 +4,7 @@ const CheckoutPage: React.FC = () => {
   return (
     <>
       <div className="max-w-6xl mx-auto px-4 py-8 grid grid-cols-1 lg:grid-cols-3 gap-8">
-        <div className="lg:col-span-2">FORMS AND SUCH WILL BE HERE</div>
-        <div className="self-start">
+        <div className="self-start sticky top-8">
           <CheckoutSummary />
         </div>
       </div>

--- a/src/components/Cart/CartDrawer/CartDrawer.test.tsx
+++ b/src/components/Cart/CartDrawer/CartDrawer.test.tsx
@@ -25,7 +25,7 @@ describe('CartDrawer', () => {
 
     expect(drawer).toHaveClass('translate-x-full');
 
-    await act(async () => {
+    act(() => {
       cartStore.openDrawer();
     });
 
@@ -64,7 +64,7 @@ describe('CartDrawer', () => {
     expect(screen.queryByText(shoe1.name)).not.toBeInTheDocument();
     expect(screen.queryByText(shoe2.name)).not.toBeInTheDocument();
 
-    await act(async () => {
+    act(() => {
       cartStore.updateQuantity(shoe1, 'Pink', '5', 'increase');
       cartStore.updateQuantity(shoe2, 'White', '6', 'increase');
     });
@@ -87,7 +87,7 @@ describe('CartDrawer', () => {
     expect(screen.getByText(shoe1.name)).toBeInTheDocument();
     expect(screen.getByText(shoe2.name)).toBeInTheDocument();
 
-    await act(async () => {
+    act(() => {
       cartStore.updateQuantity(shoe1, 'Pink', '5', 'decrease');
       cartStore.updateQuantity(shoe2, 'White', '6', 'decrease');
     });

--- a/src/components/Cart/CartDrawer/CartDrawer.test.tsx
+++ b/src/components/Cart/CartDrawer/CartDrawer.test.tsx
@@ -1,4 +1,10 @@
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import {
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+  act,
+} from '@testing-library/react';
 import CartDrawer from './CartDrawer';
 import { cartStore } from '../../../stores/cart-store';
 import { mockData } from '../../../data/MockData';
@@ -19,7 +25,9 @@ describe('CartDrawer', () => {
 
     expect(drawer).toHaveClass('translate-x-full');
 
-    cartStore.openDrawer();
+    await act(async () => {
+      cartStore.openDrawer();
+    });
 
     await waitFor(() => {
       expect(drawer).toHaveClass('translate-x-0');
@@ -56,8 +64,10 @@ describe('CartDrawer', () => {
     expect(screen.queryByText(shoe1.name)).not.toBeInTheDocument();
     expect(screen.queryByText(shoe2.name)).not.toBeInTheDocument();
 
-    cartStore.updateQuantity(shoe1, 'Pink', '5', 'increase');
-    cartStore.updateQuantity(shoe2, 'White', '6', 'increase');
+    await act(async () => {
+      cartStore.updateQuantity(shoe1, 'Pink', '5', 'increase');
+      cartStore.updateQuantity(shoe2, 'White', '6', 'increase');
+    });
 
     await waitFor(() =>
       expect(screen.queryByText('Your bag is empty.')).not.toBeInTheDocument()
@@ -77,8 +87,10 @@ describe('CartDrawer', () => {
     expect(screen.getByText(shoe1.name)).toBeInTheDocument();
     expect(screen.getByText(shoe2.name)).toBeInTheDocument();
 
-    cartStore.updateQuantity(shoe1, 'Pink', '5', 'decrease');
-    cartStore.updateQuantity(shoe2, 'White', '6', 'decrease');
+    await act(async () => {
+      cartStore.updateQuantity(shoe1, 'Pink', '5', 'decrease');
+      cartStore.updateQuantity(shoe2, 'White', '6', 'decrease');
+    });
 
     await waitFor(() =>
       expect(screen.getByText('Your bag is empty.')).toBeInTheDocument()

--- a/src/components/Cart/CartDrawer/CartDrawer.tsx
+++ b/src/components/Cart/CartDrawer/CartDrawer.tsx
@@ -26,7 +26,7 @@ const CartDrawer: React.FC = observer(() => {
         aria-hidden={!isOpen}
         className={`fixed top-0 right-0 h-full w-full max-w-[35rem] bg-gray-800 z-50 shadow-lg transition-transform duration-500 ease-in-out transform ${isOpen ? 'translate-x-0' : 'translate-x-full'}`}
       >
-        <div className="p-4 h-full flex flex-col">
+        <div className="p-4 h-full flex flex-col text-white">
           <div className="flex justify-between items-center mb-4">
             <h2 className="text-lg font-semibold">Your Bag</h2>
             <button aria-label="close" onClick={closeDrawer}>

--- a/src/components/Cart/CartDrawer/CartDrawer.tsx
+++ b/src/components/Cart/CartDrawer/CartDrawer.tsx
@@ -3,7 +3,7 @@
 import { observer } from 'mobx-react-lite';
 import { cartStore } from '../../../stores/cart-store';
 import EmptyCartContent from './CartDrawerEmpty';
-import CartItemList from './CartDrawerList';
+import CartDrawerList from './CartDrawerList';
 
 const CartDrawer: React.FC = observer(() => {
   const isOpen = cartStore.drawerOpen;
@@ -38,7 +38,7 @@ const CartDrawer: React.FC = observer(() => {
             {items.length === 0 ? (
               <EmptyCartContent onClose={closeDrawer} />
             ) : (
-              <CartItemList
+              <CartDrawerList
                 cartItems={items}
                 subtotal={subtotal}
                 onClose={closeDrawer}

--- a/src/components/Cart/CartDrawer/CartDrawerList.tsx
+++ b/src/components/Cart/CartDrawer/CartDrawerList.tsx
@@ -28,7 +28,7 @@ const CartDrawerList: React.FC<CartItemListProps> = ({
         <i>Shipping & taxes calculated at checkout</i>
       </div>
       <Link
-        href="/cart"
+        href="/checkout"
         className="block w-full mt-4 bg-black text-white text-center text-lg font-medium py-3 rounded hover:bg-gray-900 transition"
         aria-label="checkout button"
         onClick={onClose}

--- a/src/components/Cart/CartItem.tsx
+++ b/src/components/Cart/CartItem.tsx
@@ -25,7 +25,8 @@ const CartItem: React.FC<Props> = observer(({ cartItem, compact = false }) => {
           src={imageUrl}
           alt={shoe.name}
           fill
-          sizes="(max-width: 768px) 100vw, 160px"
+          sizes="160px"
+          quality={100}
           className="object-cover rounded"
         />
       </div>

--- a/src/components/Checkout/CheckoutSummary.test.tsx
+++ b/src/components/Checkout/CheckoutSummary.test.tsx
@@ -20,38 +20,43 @@ describe('CheckoutSummary', () => {
 
   it('renders the desktop order summary title', () => {
     render(<CheckoutSummary />);
-    const desktopSection = screen.getByLabelText('Desktop summary');
+    const desktopSection = screen.getByRole('presentation', {
+      name: 'Order summary',
+    });
     const title = within(desktopSection).getAllByText('Order Summary');
+
     expect(title).toHaveLength(1);
   });
 
   it('renders only one visible cart item name in desktop summary', () => {
     render(<CheckoutSummary />);
 
-    const desktopSection = screen.getByLabelText('Desktop summary');
-    const item = within(desktopSection).getAllByText(mockCartItem.shoe.name);
-    expect(item).toHaveLength(1);
+    expect(screen.getAllByText(mockCartItem.shoe.name)).toHaveLength(2);
   });
 
   it('renders subtotal, shipping, taxes, and total', () => {
     render(<CheckoutSummary />);
-    expect(screen.getByLabelText('subtotal')).toBeInTheDocument();
-    expect(screen.getByLabelText('shipping')).toBeInTheDocument();
-    expect(screen.getByLabelText('estimated taxes')).toBeInTheDocument();
-    expect(screen.getByLabelText('total')).toBeInTheDocument();
+
+    expect(screen.getByText('Subtotal')).toBeInTheDocument();
+    expect(screen.getByText('Shipping')).toBeInTheDocument();
+    expect(screen.getByText('Estimated taxes')).toBeInTheDocument();
+    expect(screen.getByText('Total')).toBeInTheDocument();
   });
 
   it('shows FREE shipping if subtotal is above 150', () => {
     mockCartTotal = 160;
     render(<CheckoutSummary />);
-    expect(screen.getByLabelText('shipping')).toHaveTextContent('FREE');
-    expect(screen.getByLabelText('savings')).toBeInTheDocument();
+
+    expect(screen.getByText('FREE')).toBeInTheDocument();
+    expect(screen.getByText('sell')).toBeInTheDocument();
   });
 
   it('shows $20.00 shipping if subtotal is below 150', () => {
     mockCartTotal = 120;
     render(<CheckoutSummary />);
-    expect(screen.getByLabelText('shipping')).toHaveTextContent('$20.00');
-    expect(screen.queryByLabelText('savings')).not.toBeInTheDocument();
+
+    expect(screen.getByText('$20.00')).toBeInTheDocument();
+    expect(screen.queryByText('sell')).not.toBeInTheDocument();
+    expect(screen.queryByText('FREE')).not.toBeInTheDocument();
   });
 });

--- a/src/components/Checkout/CheckoutSummary.test.tsx
+++ b/src/components/Checkout/CheckoutSummary.test.tsx
@@ -20,9 +20,7 @@ describe('CheckoutSummary', () => {
 
   it('renders the desktop order summary title', () => {
     render(<CheckoutSummary />);
-    const desktopSection = screen.getByRole('presentation', {
-      name: 'Order summary',
-    });
+    const desktopSection = screen.getByLabelText('Order summary');
     const title = within(desktopSection).getAllByText('Order Summary');
 
     expect(title).toHaveLength(1);

--- a/src/components/Checkout/CheckoutSummary.test.tsx
+++ b/src/components/Checkout/CheckoutSummary.test.tsx
@@ -1,0 +1,57 @@
+import { render, screen, within } from '@testing-library/react';
+import CheckoutSummary from './CheckoutSummary';
+import { mockCartItem } from '../Cart/__mocks__/mockCartItem';
+
+let mockCartTotal = 0;
+
+jest.mock('../../stores/cart-store', () => ({
+  cartStore: {
+    getCartItems: () => [mockCartItem],
+    get cartTotal() {
+      return mockCartTotal;
+    },
+  },
+}));
+
+describe('CheckoutSummary', () => {
+  beforeEach(() => {
+    mockCartTotal = 0;
+  });
+
+  it('renders the desktop order summary title', () => {
+    render(<CheckoutSummary />);
+    const desktopSection = screen.getByLabelText('Desktop summary');
+    const title = within(desktopSection).getAllByText('Order Summary');
+    expect(title).toHaveLength(1);
+  });
+
+  it('renders only one visible cart item name in desktop summary', () => {
+    render(<CheckoutSummary />);
+
+    const desktopSection = screen.getByLabelText('Desktop summary');
+    const item = within(desktopSection).getAllByText(mockCartItem.shoe.name);
+    expect(item).toHaveLength(1);
+  });
+
+  it('renders subtotal, shipping, taxes, and total', () => {
+    render(<CheckoutSummary />);
+    expect(screen.getByLabelText('subtotal')).toBeInTheDocument();
+    expect(screen.getByLabelText('shipping')).toBeInTheDocument();
+    expect(screen.getByLabelText('estimated taxes')).toBeInTheDocument();
+    expect(screen.getByLabelText('total')).toBeInTheDocument();
+  });
+
+  it('shows FREE shipping if subtotal is above 150', () => {
+    mockCartTotal = 160;
+    render(<CheckoutSummary />);
+    expect(screen.getByLabelText('shipping')).toHaveTextContent('FREE');
+    expect(screen.getByLabelText('savings')).toBeInTheDocument();
+  });
+
+  it('shows $20.00 shipping if subtotal is below 150', () => {
+    mockCartTotal = 120;
+    render(<CheckoutSummary />);
+    expect(screen.getByLabelText('shipping')).toHaveTextContent('$20.00');
+    expect(screen.queryByLabelText('savings')).not.toBeInTheDocument();
+  });
+});

--- a/src/components/Checkout/CheckoutSummary.tsx
+++ b/src/components/Checkout/CheckoutSummary.tsx
@@ -11,11 +11,7 @@ const CheckoutSummary: React.FC = observer(() => {
       <MobileCheckoutSummary />
       <div className="hidden lg:block mb-3">
         <div className="flex justify-between items-center pb-0 mb-3">
-          <h2
-            className="text-xl font-semibold"
-            role="presentation"
-            aria-label="Order summary"
-          >
+          <h2 className="text-xl font-semibold" aria-label="Order summary">
             Order Summary
           </h2>
         </div>

--- a/src/components/Checkout/CheckoutSummary.tsx
+++ b/src/components/Checkout/CheckoutSummary.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import { observer } from 'mobx-react-lite';
+import MobileCheckoutSummary from './MobileCheckoutSummary';
+import CheckoutSummaryItemList from './CheckoutSummaryItemList';
+import CheckoutSummaryPrice from './CheckoutSummaryPrice';
+
+const CheckoutSummary: React.FC = observer(() => {
+  return (
+    <div className="border rounded-lg p-4 lg:px-6 shadow-md space-y-6">
+      <MobileCheckoutSummary />
+      <div className="hidden lg:block mb-3" aria-label="Desktop summary">
+        <div className="flex justify-between items-center pb-0 mb-3">
+          <h2 className="text-xl font-semibold" aria-label="Order summary">
+            Order Summary
+          </h2>
+        </div>
+        <CheckoutSummaryItemList />
+      </div>
+      <CheckoutSummaryPrice />
+    </div>
+  );
+});
+
+export default CheckoutSummary;

--- a/src/components/Checkout/CheckoutSummary.tsx
+++ b/src/components/Checkout/CheckoutSummary.tsx
@@ -9,9 +9,13 @@ const CheckoutSummary: React.FC = observer(() => {
   return (
     <div className="border rounded-lg p-4 lg:px-6 shadow-md space-y-6">
       <MobileCheckoutSummary />
-      <div className="hidden lg:block mb-3" aria-label="Desktop summary">
+      <div className="hidden lg:block mb-3">
         <div className="flex justify-between items-center pb-0 mb-3">
-          <h2 className="text-xl font-semibold" aria-label="Order summary">
+          <h2
+            className="text-xl font-semibold"
+            role="presentation"
+            aria-label="Order summary"
+          >
             Order Summary
           </h2>
         </div>

--- a/src/components/Checkout/CheckoutSummaryItemList.test.tsx
+++ b/src/components/Checkout/CheckoutSummaryItemList.test.tsx
@@ -1,0 +1,26 @@
+import { render, screen } from '@testing-library/react';
+import CheckoutSummaryItemList from './CheckoutSummaryItemList';
+import { cartStore } from '../../stores/cart-store';
+import { mockCartItem } from '../Cart/__mocks__/mockCartItem';
+
+describe('CheckoutSummaryItemList', () => {
+  it('renders cart items correctly', () => {
+    cartStore.getCartItems = jest.fn().mockReturnValue([mockCartItem]);
+    render(<CheckoutSummaryItemList />);
+
+    expect(screen.getByText("UltraBoost 21 Women's")).toBeInTheDocument();
+    expect(screen.getByText('Pink / 9')).toBeInTheDocument();
+    expect(screen.getByText('2')).toBeInTheDocument();
+    expect(screen.getByText('$360.00')).toBeInTheDocument();
+    expect(screen.getByAltText("UltraBoost 21 Women's")).toBeInTheDocument();
+  });
+
+  it('renders nothing if cart is empty', () => {
+    cartStore.getCartItems = jest.fn().mockReturnValue([]);
+    render(<CheckoutSummaryItemList />);
+
+    expect(
+      screen.queryByText(/UltraBoost 21 Women's/i)
+    ).not.toBeInTheDocument();
+  });
+});

--- a/src/components/Checkout/CheckoutSummaryItemList.tsx
+++ b/src/components/Checkout/CheckoutSummaryItemList.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import { observer } from 'mobx-react-lite';
+import { cartStore } from '../../stores/cart-store';
+import Image from 'next/image';
+
+const CheckoutSummaryItemList: React.FC = observer(() => {
+  const cartItems = cartStore.getCartItems();
+
+  return (
+    <div className="space-y-4">
+      {cartItems.map((item, index) => (
+        <div key={index} className="flex gap-4 items-start">
+          <div className="relative w-16 h-16 shrink-0">
+            <Image
+              src={item.shoe.colorImages[item.selectedColor][0]}
+              alt={item.shoe.name}
+              fill
+              sizes="64px"
+              quality={100}
+              className="rounded object-cover"
+            />
+            <div className="absolute -top-2 -right-2 bg-white text-black text-xs font-semibold px-1.5 py-0.5 rounded-full">
+              {item.quantity}
+            </div>
+          </div>
+          <div className="flex-1">
+            <p className="font-medium">{item.shoe.name}</p>
+            <p className="text-sm text-gray-400">
+              {item.selectedColor} / {item.selectedSize}
+            </p>
+          </div>
+          <div className="min-w-max text-sm font-semibold">
+            ${(item.selectedPrice * item.quantity).toFixed(2)}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+});
+
+export default CheckoutSummaryItemList;

--- a/src/components/Checkout/CheckoutSummaryPrice.test.tsx
+++ b/src/components/Checkout/CheckoutSummaryPrice.test.tsx
@@ -1,0 +1,53 @@
+import { render, screen } from '@testing-library/react';
+import CheckoutSummaryPrice from './CheckoutSummaryPrice';
+
+jest.mock('../../stores/cart-store', () => {
+  return {
+    cartStore: {
+      get cartTotal() {
+        return mockCartTotal;
+      },
+    },
+  };
+});
+
+let mockCartTotal = 0;
+
+describe('CheckoutSummaryPrice', () => {
+  test('renders with free shipping when subtotal is 0', () => {
+    mockCartTotal = 0;
+    render(<CheckoutSummaryPrice />);
+
+    expect(screen.getByLabelText('subtotal')).toHaveTextContent('$0.00');
+    expect(screen.getByLabelText('shipping')).toHaveTextContent('FREE');
+    expect(screen.getByLabelText('estimated taxes')).toHaveTextContent('$0.00');
+    expect(screen.getByLabelText('total')).toHaveTextContent('$0.00');
+    expect(screen.getByLabelText('savings')).toHaveTextContent(
+      'TOTAL SAVINGS $20.00'
+    );
+  });
+
+  test('renders $20 shipping when subtotal is greater than 0, but less than 150', () => {
+    mockCartTotal = 100;
+    render(<CheckoutSummaryPrice />);
+
+    expect(screen.getByLabelText('subtotal')).toHaveTextContent('$100.00');
+    expect(screen.getByLabelText('shipping')).toHaveTextContent('$20.00');
+    expect(screen.getByLabelText('estimated taxes')).toHaveTextContent('$0.00');
+    expect(screen.getByLabelText('total')).toHaveTextContent('$120.00');
+    expect(screen.queryByLabelText('savings')).not.toBeInTheDocument();
+  });
+
+  test('renders free shipping and savings when subtotal is 150 or more', () => {
+    mockCartTotal = 200;
+    render(<CheckoutSummaryPrice />);
+
+    expect(screen.getByLabelText('subtotal')).toHaveTextContent('$200.00');
+    expect(screen.getByLabelText('shipping')).toHaveTextContent('FREE');
+    expect(screen.getByLabelText('estimated taxes')).toHaveTextContent('$0.00');
+    expect(screen.getByLabelText('total')).toHaveTextContent('$200.00');
+    expect(screen.getByLabelText('savings')).toHaveTextContent(
+      'TOTAL SAVINGS $20.00'
+    );
+  });
+});

--- a/src/components/Checkout/CheckoutSummaryPrice.test.tsx
+++ b/src/components/Checkout/CheckoutSummaryPrice.test.tsx
@@ -14,40 +14,35 @@ jest.mock('../../stores/cart-store', () => {
 let mockCartTotal = 0;
 
 describe('CheckoutSummaryPrice', () => {
-  test('renders with free shipping when subtotal is 0', () => {
+  it('renders with free shipping when subtotal is 0', () => {
     mockCartTotal = 0;
     render(<CheckoutSummaryPrice />);
 
-    expect(screen.getByLabelText('subtotal')).toHaveTextContent('$0.00');
-    expect(screen.getByLabelText('shipping')).toHaveTextContent('FREE');
-    expect(screen.getByLabelText('estimated taxes')).toHaveTextContent('$0.00');
-    expect(screen.getByLabelText('total')).toHaveTextContent('$0.00');
-    expect(screen.getByLabelText('savings')).toHaveTextContent(
-      'TOTAL SAVINGS $20.00'
-    );
+    expect(screen.queryByText('$100.00')).not.toBeInTheDocument();
+    expect(screen.queryByText('$120.00')).not.toBeInTheDocument();
+    expect(screen.getByText('FREE')).toBeInTheDocument();
+    expect(screen.getByText('sell')).toBeInTheDocument();
   });
 
-  test('renders $20 shipping when subtotal is greater than 0, but less than 150', () => {
+  it('renders $20 shipping when subtotal is greater than 0, but less than 150', () => {
     mockCartTotal = 100;
     render(<CheckoutSummaryPrice />);
 
-    expect(screen.getByLabelText('subtotal')).toHaveTextContent('$100.00');
-    expect(screen.getByLabelText('shipping')).toHaveTextContent('$20.00');
-    expect(screen.getByLabelText('estimated taxes')).toHaveTextContent('$0.00');
-    expect(screen.getByLabelText('total')).toHaveTextContent('$120.00');
-    expect(screen.queryByLabelText('savings')).not.toBeInTheDocument();
+    expect(screen.getByText('$100.00')).toBeInTheDocument();
+    expect(screen.getByText('$20.00')).toBeInTheDocument();
+    expect(screen.getByText('$0.00')).toBeInTheDocument();
+    expect(screen.getByText('$120.00')).toBeInTheDocument();
+    expect(screen.queryByText('sell')).not.toBeInTheDocument();
+    expect(screen.queryByText('TOTAL SAVINGS $20.00')).not.toBeInTheDocument();
   });
 
-  test('renders free shipping and savings when subtotal is 150 or more', () => {
+  it('renders free shipping and savings when subtotal is 150 or more', () => {
     mockCartTotal = 200;
     render(<CheckoutSummaryPrice />);
 
-    expect(screen.getByLabelText('subtotal')).toHaveTextContent('$200.00');
-    expect(screen.getByLabelText('shipping')).toHaveTextContent('FREE');
-    expect(screen.getByLabelText('estimated taxes')).toHaveTextContent('$0.00');
-    expect(screen.getByLabelText('total')).toHaveTextContent('$200.00');
-    expect(screen.getByLabelText('savings')).toHaveTextContent(
-      'TOTAL SAVINGS $20.00'
-    );
+    expect(screen.getAllByText('$200.00')).toHaveLength(2);
+    expect(screen.getByText('FREE')).toBeInTheDocument();
+    expect(screen.getByText('sell')).toBeInTheDocument();
+    expect(screen.getByText('TOTAL SAVINGS $20.00')).toBeInTheDocument();
   });
 });

--- a/src/components/Checkout/CheckoutSummaryPrice.tsx
+++ b/src/components/Checkout/CheckoutSummaryPrice.tsx
@@ -12,11 +12,11 @@ const CheckoutSummaryPrice: React.FC = observer(() => {
 
   return (
     <div className="space-y-3 text-sm border-t pt-3">
-      <div className="flex justify-between" aria-label="subtotal">
+      <div className="flex justify-between">
         <span>Subtotal</span>
         <span>${subtotal.toFixed(2)}</span>
       </div>
-      <div className="flex justify-between" aria-label="shipping">
+      <div className="flex justify-between">
         <span>Shipping</span>
         <span>
           {shippingCost === 0 ? (
@@ -25,22 +25,16 @@ const CheckoutSummaryPrice: React.FC = observer(() => {
           {shippingCost === 0 ? 'FREE' : `$${shippingCost.toFixed(2)}`}
         </span>
       </div>
-      <div className="flex justify-between" aria-label="estimated taxes">
+      <div className="flex justify-between">
         <span>Estimated taxes</span>
         <span>${taxes.toFixed(2)}</span>
       </div>
-      <div
-        className="flex justify-between font-semibold text-base border-t pt-3 mb-1"
-        aria-label="total"
-      >
+      <div className="flex justify-between font-semibold text-base border-t pt-3 mb-1">
         <span>Total</span>
         <span>${total.toFixed(2)}</span>
       </div>
       {savings > 0 && (
-        <div
-          className="text-sm text-green-400 font-medium pt-0"
-          aria-label="savings"
-        >
+        <div className="text-sm text-green-400 font-medium pt-0">
           <i className="material-icons rotate-y-180 align-middle">sell</i> TOTAL
           SAVINGS ${savings.toFixed(2)}
         </div>

--- a/src/components/Checkout/CheckoutSummaryPrice.tsx
+++ b/src/components/Checkout/CheckoutSummaryPrice.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import { observer } from 'mobx-react-lite';
+import { cartStore } from '../../stores/cart-store';
+
+const CheckoutSummaryPrice: React.FC = observer(() => {
+  const subtotal = cartStore.cartTotal;
+  const shippingCost = subtotal > 0 && subtotal < 150 ? 20 : 0;
+  const taxes = 0;
+  const total = subtotal + shippingCost + taxes;
+  const savings = shippingCost > 0 ? 0 : 20.0;
+
+  return (
+    <div className="space-y-3 text-sm border-t pt-3">
+      <div className="flex justify-between" aria-label="subtotal">
+        <span>Subtotal</span>
+        <span>${subtotal.toFixed(2)}</span>
+      </div>
+      <div className="flex justify-between" aria-label="shipping">
+        <span>Shipping</span>
+        <span>
+          {shippingCost === 0 ? (
+            <span className="line-through text-gray-500 mr-1">$20.00</span>
+          ) : null}
+          {shippingCost === 0 ? 'FREE' : `$${shippingCost.toFixed(2)}`}
+        </span>
+      </div>
+      <div className="flex justify-between" aria-label="estimated taxes">
+        <span>Estimated taxes</span>
+        <span>${taxes.toFixed(2)}</span>
+      </div>
+      <div
+        className="flex justify-between font-semibold text-base border-t pt-3 mb-1"
+        aria-label="total"
+      >
+        <span>Total</span>
+        <span>${total.toFixed(2)}</span>
+      </div>
+      {savings > 0 && (
+        <div
+          className="text-sm text-green-400 font-medium pt-0"
+          aria-label="savings"
+        >
+          <i className="material-icons rotate-y-180 align-middle">sell</i> TOTAL
+          SAVINGS ${savings.toFixed(2)}
+        </div>
+      )}
+    </div>
+  );
+});
+
+export default CheckoutSummaryPrice;

--- a/src/components/Checkout/MobileCheckoutSummary.test.tsx
+++ b/src/components/Checkout/MobileCheckoutSummary.test.tsx
@@ -25,9 +25,9 @@ describe('MobileCheckoutSummary', () => {
     expect(screen.getByText('Order Summary')).toBeInTheDocument();
     expect(screen.getByText('Show')).toBeInTheDocument();
     expect(screen.getByText('keyboard_arrow_down')).toBeInTheDocument();
-    expect(
-      screen.getByRole('presentation', { name: 'Order Summary Items' })
-    ).toHaveStyle('max-height: 0px');
+    expect(screen.getByLabelText('Order Summary Items')).toHaveStyle(
+      'max-height: 0px'
+    );
   });
 
   it('shows CheckoutSummaryItemList when "Show" button is clicked', async () => {
@@ -35,15 +35,15 @@ describe('MobileCheckoutSummary', () => {
 
     expect(screen.getByText('Show')).toBeInTheDocument();
     expect(screen.getByText('keyboard_arrow_down')).toBeInTheDocument();
-    expect(
-      screen.getByRole('presentation', { name: 'Order Summary Items' })
-    ).toHaveStyle('max-height: 0px');
+    expect(screen.getByLabelText('Order Summary Items')).toHaveStyle(
+      'max-height: 0px'
+    );
 
     fireEvent.click(screen.getByText('Show'));
 
-    expect(
-      screen.getByRole('presentation', { name: 'Order Summary Items' })
-    ).toHaveStyle('max-height: 3000px');
+    expect(screen.getByLabelText('Order Summary Items')).toHaveStyle(
+      'max-height: 3000px'
+    );
     expect(screen.getByText('Hide')).toBeInTheDocument();
     expect(screen.getByText('keyboard_arrow_up')).toBeInTheDocument();
   });
@@ -55,17 +55,15 @@ describe('MobileCheckoutSummary', () => {
     fireEvent.click(screen.getByText('Hide'));
 
     expect(screen.getByText('Show')).toBeInTheDocument();
-    expect(
-      screen.getByRole('presentation', { name: 'Order Summary Items' })
-    ).toHaveStyle('max-height: 0px');
+    expect(screen.getByLabelText('Order Summary Items')).toHaveStyle(
+      'max-height: 0px'
+    );
   });
 
   it('animates the visibility correctly', async () => {
     render(<MobileCheckoutSummary />);
 
-    const content = screen.getByRole('presentation', {
-      name: 'Order Summary Items',
-    });
+    const content = screen.getByLabelText('Order Summary Items');
     expect(content).toHaveStyle('max-height: 0px');
 
     fireEvent.click(screen.getByText('Show'));

--- a/src/components/Checkout/MobileCheckoutSummary.test.tsx
+++ b/src/components/Checkout/MobileCheckoutSummary.test.tsx
@@ -1,0 +1,75 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import MobileCheckoutSummary from './MobileCheckoutSummary';
+import { cartStore } from '../../stores/cart-store';
+import { mockCartItem } from '../Cart/__mocks__/mockCartItem';
+
+jest.mock('../../stores/cart-store', () => ({
+  cartStore: {
+    getCartItems: jest.fn(),
+  },
+}));
+
+Object.defineProperty(HTMLDivElement.prototype, 'scrollHeight', {
+  value: 3000,
+  writable: true,
+});
+
+describe('MobileCheckoutSummary', () => {
+  beforeEach(() => {
+    cartStore.getCartItems = jest.fn().mockReturnValue([mockCartItem]);
+  });
+
+  it('renders the "Order Summary" title and "Show" button initially', () => {
+    render(<MobileCheckoutSummary />);
+
+    expect(screen.getByText('Order Summary')).toBeInTheDocument();
+    expect(screen.getByText('Show')).toBeInTheDocument();
+    expect(screen.getByText('keyboard_arrow_down')).toBeInTheDocument();
+    expect(
+      screen.getByRole('presentation', { name: 'Order Summary Items' })
+    ).toHaveStyle('max-height: 0px');
+  });
+
+  it('shows CheckoutSummaryItemList when "Show" button is clicked', async () => {
+    render(<MobileCheckoutSummary />);
+
+    expect(screen.getByText('Show')).toBeInTheDocument();
+    expect(screen.getByText('keyboard_arrow_down')).toBeInTheDocument();
+    expect(
+      screen.getByRole('presentation', { name: 'Order Summary Items' })
+    ).toHaveStyle('max-height: 0px');
+
+    fireEvent.click(screen.getByText('Show'));
+
+    expect(
+      screen.getByRole('presentation', { name: 'Order Summary Items' })
+    ).toHaveStyle('max-height: 3000px');
+    expect(screen.getByText('Hide')).toBeInTheDocument();
+    expect(screen.getByText('keyboard_arrow_up')).toBeInTheDocument();
+  });
+
+  it('hides CheckoutSummaryItemList when "Hide" button is clicked', async () => {
+    render(<MobileCheckoutSummary />);
+    fireEvent.click(screen.getByText('Show'));
+
+    fireEvent.click(screen.getByText('Hide'));
+
+    expect(screen.getByText('Show')).toBeInTheDocument();
+    expect(
+      screen.getByRole('presentation', { name: 'Order Summary Items' })
+    ).toHaveStyle('max-height: 0px');
+  });
+
+  it('animates the visibility correctly', async () => {
+    render(<MobileCheckoutSummary />);
+
+    const content = screen.getByRole('presentation', {
+      name: 'Order Summary Items',
+    });
+    expect(content).toHaveStyle('max-height: 0px');
+
+    fireEvent.click(screen.getByText('Show'));
+
+    expect(content).toHaveStyle('max-height: 3000px');
+  });
+});

--- a/src/components/Checkout/MobileCheckoutSummary.tsx
+++ b/src/components/Checkout/MobileCheckoutSummary.tsx
@@ -31,7 +31,6 @@ const MobileCheckoutSummary: React.FC = () => {
         </div>
         <div
           ref={contentRef}
-          role="presentation"
           aria-label="Order Summary Items"
           className="overflow-hidden transition-[max-height] duration-300 ease-in-out mb-3"
           style={{ maxHeight: showItems ? height : '0px' }}

--- a/src/components/Checkout/MobileCheckoutSummary.tsx
+++ b/src/components/Checkout/MobileCheckoutSummary.tsx
@@ -1,0 +1,48 @@
+'use client';
+
+import { useState, useRef, useEffect } from 'react';
+import CheckoutSummaryItemList from './CheckoutSummaryItemList';
+
+const MobileCheckoutSummary: React.FC = () => {
+  const [showItems, setShowItems] = useState(false);
+  const contentRef = useRef<HTMLDivElement>(null);
+  const [height, setHeight] = useState('0px');
+
+  useEffect(() => {
+    if (contentRef.current) {
+      setHeight(showItems ? `${contentRef.current.scrollHeight}px` : '0px');
+    }
+  }, [showItems]);
+
+  return (
+    <>
+      <div className="lg:hidden mb-0" aria-label="Mobile summary">
+        <div
+          onClick={() => setShowItems(!showItems)}
+          className="flex justify-between items-center cursor-pointer select-none pb-0 mb-0"
+        >
+          <h2 className="text-xl font-semibold">Order Summary</h2>
+          <div className="text-sm flex items-center gap-1">
+            <span>{showItems ? 'Hide' : 'Show'}</span>
+            <i className="material-icons align-middle">
+              {showItems ? 'keyboard_arrow_up' : 'keyboard_arrow_down'}
+            </i>
+          </div>
+        </div>
+        <div
+          ref={contentRef}
+          role="presentation"
+          aria-label="Order Summary Items"
+          className="overflow-hidden transition-[max-height] duration-300 ease-in-out mb-3"
+          style={{ maxHeight: showItems ? height : '0px' }}
+        >
+          <div className="pt-4">
+            <CheckoutSummaryItemList />
+          </div>
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default MobileCheckoutSummary;

--- a/src/components/Checkout/MobileCheckoutSummary.tsx
+++ b/src/components/Checkout/MobileCheckoutSummary.tsx
@@ -16,7 +16,7 @@ const MobileCheckoutSummary: React.FC = () => {
 
   return (
     <>
-      <div className="lg:hidden mb-0" aria-label="Mobile summary">
+      <div className="lg:hidden mb-0">
         <div
           onClick={() => setShowItems(!showItems)}
           className="flex justify-between items-center cursor-pointer select-none pb-0 mb-0"

--- a/src/components/Nav/CartButton.test.tsx
+++ b/src/components/Nav/CartButton.test.tsx
@@ -16,7 +16,7 @@ describe('CartButton', () => {
       brand: '',
       sizes: ['10'],
       colors: ['Red'],
-      colorImages: { Red: 'red-image-url' },
+      colorImages: { Red: ['red-image-url'] },
       description: '',
       prices: { Red: 100 },
     };


### PR DESCRIPTION
Added checkout summary components and tests.
Desktop view is straight forward, summary will be on the right side of the page, forms on the left (coming soon)
Mobile view will stack and the images and such will hide by default to keep from having a longer scroll and drive to hit the pay button.

also fixed a few jest warning from the mocking of Image and using act that were pestering.

https://github.com/user-attachments/assets/dbfbd3fd-d61c-475f-b83f-409f07f20a09

Checkout page (mobile) closed (default)
![image](https://github.com/user-attachments/assets/84905a34-af82-47bf-995b-dee4d5b44660)

Checkout page (mobile) opened
![image](https://github.com/user-attachments/assets/05a43039-3139-48d0-8653-65db603084cd)

Checkout page (desktop)
![image](https://github.com/user-attachments/assets/90fcfafa-4b50-476c-a972-a5bff3f42445)
